### PR TITLE
hotfix, log

### DIFF
--- a/bin/pdfbeads
+++ b/bin/pdfbeads
@@ -32,7 +32,6 @@
 #######################################################################
 
 require 'optparse'
-require 'iconv'
 require 'time'
 
 require 'pdfbeads'

--- a/bin/pdfbeads
+++ b/bin/pdfbeads
@@ -33,6 +33,7 @@
 
 require 'optparse'
 require 'time'
+require 'multiio'
 
 require 'pdfbeads'
 include PDFBeads
@@ -45,7 +46,9 @@ pdfargs  = Hash[
   :textpdf        => nil,
   :delfiles       => false,
   :debug          => false,
-  :rtl            => false
+  :rtl            => false,
+  :is_log         => false,
+  :file_for_log   => 'out.log'
 ]
 pageargs = Hash[
   :threshold       => 1,
@@ -65,7 +68,7 @@ OptionParser.new() do |opts|
   opts.set_summary_width(24)
   opts.set_summary_indent("  ")
 
-  opts.banner = "Usage: pdfbeads [options] [files to process] > out.pdf"
+  opts.banner = "Usage:\tpdfbeads [options] [files to process] -o out.pdf\n\tor\n\tpdfbeads [options] [files to process] > out.pdf"
 
   opts.separator "\n"
   opts.separator "PDF file properties:\n"
@@ -215,6 +218,12 @@ OptionParser.new() do |opts|
                 "text layer visible and using uncompressed page streams") do |dbg|
     pdfargs[:debug] = dbg
   end
+  opts.on("-l", "--log FILE", 
+                "Save to FILE, STDOUT and STDERR.",
+                "Works only when the option -o / --output is set") do |f|
+    pdfargs[:file_for_log] = f
+    pdfargs[:is_log] = true
+  end
   opts.on_tail("-h", "--help", "Show this message") do
     puts opts
     exit
@@ -227,6 +236,16 @@ if ARGV.length == 0
   files = Dir.glob("*").sort
 else
   files = ARGV.sort
+end
+
+if pdfargs[:is_log]
+  if outpath.eql? 'STDOUT'
+    $stderr.puts( "Warning: option -o / --output is not set." )
+    $stderr.puts( "\tthe -l / --log option is ignored." )
+  else
+    STDOUT.reopen MultiIO.instance(pdfargs[:file_for_log]).setTargets([STDOUT,STDERR])
+    STDERR.reopen STDOUT 
+  end
 end
 
 pages = PageDataProvider.new( files,pageargs )

--- a/lib/multiio.rb
+++ b/lib/multiio.rb
@@ -1,0 +1,48 @@
+# encoding: UTF-8
+
+######################################################################
+#
+# Based on example code written by Tiago Lopo
+#
+# from https://stackoverflow.com/questions/9433924/46817584#46817584
+#
+#######################################################################
+
+require 'singleton'
+
+class MultiIO < File
+  include Singleton 
+  @@path = 'out.log'
+  @@targets = []
+  @@mutex = Mutex.new
+
+  def self.instance(path)
+    @@path = path unless path.nil?
+    self.open(@@path,'w+')
+  end
+
+  def puts(str)
+    write "#{str}"
+  end
+
+  def write(str)
+    @@mutex.synchronize do 
+      @@targets.each { |t| t.write str; flush }
+    end
+  end
+
+  def setTargets(targets)
+    raise 'setTargets is a one-off operation' unless @@targets.length < 1
+    targets.each do |t|
+       @@targets.push STDOUT.clone if t == STDOUT 
+       @@targets.push STDERR.clone if t == STDERR
+       break if t == STDOUT or t == STDERR  
+    end
+    @@targets.push(File.open(@@path,'w+'))
+    self
+  end
+
+  def close
+    @@targets.each {|t| t.close}
+  end
+end

--- a/lib/pdfbeads.rb
+++ b/lib/pdfbeads.rb
@@ -31,7 +31,7 @@
 #######################################################################
 
 require 'zlib'
-
+require 'open3'
 require 'rmagick'
 include Magick
 

--- a/lib/pdfbeads.rb
+++ b/lib/pdfbeads.rb
@@ -32,7 +32,7 @@
 
 require 'zlib'
 
-require 'RMagick'
+require 'rmagick'
 include Magick
 
 begin

--- a/lib/pdfbeads/pdfpage.rb
+++ b/lib/pdfbeads/pdfpage.rb
@@ -477,11 +477,13 @@ class PDFBeads::PageDataProvider < Array
         # stage only if both the dictionary and each of the individual pages
         # are already found on the disk
         if needs_update
-          IO.popen("jbig2 -s -p -t #{threshold} " << toConvert.join(' ') ) do |f|
-            out = f.gets
-            $stderr.puts out unless out.nil?
-          end
-          return false if $?.exitstatus > 0
+          exit_status = 0
+          Open3.popen3("jbig2 -s -p -t #{threshold} " << toConvert.join(' ')){|stdin, stdout, stderr, wait_thr|
+            puts "#{stdout.read}"
+            puts "#{stderr.read}"
+            exit_status = wait_thr.value.exitstatus
+          }
+          return false if exit_status > 0
 
           toConvert.each_index do |j|
             oname = sprintf( "output.%04d",j )


### PR DESCRIPTION
STDERR and STDOUT save to file (-l / --log FILE)
fix crash due to require "iconv" in unused space.
Now works on ruby from 1.9.3 to 2.3.  
On version >2.3 with the new DevKit ( MSYS2), libraries for rmagick are not compiled - could not verify the correct pdfbeads execution